### PR TITLE
Ability to use DKIM header in mail with fastnloud/zf2-dkim module.

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -72,7 +72,7 @@ class Module implements AutoloaderProviderInterface
 	    					$controllerPlugin->setMailTransport($transport);
 	    				break;
 
-	    				case 'sentmail':
+	    				case 'sendmail':
 	    					default:
 	    						$transport = new \Zend\Mail\Transport\Sendmail();
 	    						$controllerPlugin->setMailTransport($transport);

--- a/src/EmailZF2/Controller/Plugin/Mailer.php
+++ b/src/EmailZF2/Controller/Plugin/Mailer.php
@@ -69,6 +69,11 @@ class Mailer extends AbstractPlugin
         } else {
             $mail->addReplyTo($this->_from_mail, $this->_from_name);
         }
+        if(isset($data['dkimSign']))
+        {
+            $signer = $this->getController()->getServiceLocator()->get('DkimSigner');
+            $signer->signMessage($mail);
+        }
         
         $mail->setSubject($data['subject']);
 


### PR DESCRIPTION
If we need to send letters with DKIM header in ZF, we can use module fastnloud/zf2-dkim

1) You create DKIM keys (see http://dkimcore.org/specification.html).
2) Install fastnloud/zf2-dkim module in your ZF project.
3) Use it with  vikey89/EmailZF2 like:

``` php
$view = new ViewModel(array(
                'fullname' => 'Vincenzo Provenza',
            ));
$view->setTerminal(true);
$view->setTemplate('Application/view/emails/hello_world');
$this->mailerZF2()->send(array(
    'to' => 'email@domain.it',
    'subject' => 'This is subject',
    'dkimSign' => true
), $view);
```
